### PR TITLE
Use grunt-jscs instead of grunt-jscs-checker.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,7 +58,7 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks("grunt-contrib-clean");
 	grunt.loadNpmTasks("grunt-contrib-watch");
 	grunt.loadNpmTasks("grunt-contrib-jshint");
-	grunt.loadNpmTasks("grunt-jscs-checker");
+	grunt.loadNpmTasks("grunt-jscs");
 	grunt.loadNpmTasks("grunt-mocha-istanbul");
 
 	grunt.registerTask("test", [ "mocha_istanbul:coverage" ]);

--- a/core/index.js
+++ b/core/index.js
@@ -22,7 +22,7 @@ var CoreGenerator = module.exports = function CoreGenerator () {
 		"grunt-cli",
 		"grunt-contrib-clean",
 		"grunt-contrib-watch",
-		"grunt-jscs-checker",
+		"grunt-jscs",
 		"grunt-contrib-jshint",
 		"grunt-mocha-istanbul"
 	];

--- a/core/templates/_Gruntfile.js
+++ b/core/templates/_Gruntfile.js
@@ -66,7 +66,7 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks("grunt-contrib-clean");
 	grunt.loadNpmTasks("grunt-contrib-watch");
 	grunt.loadNpmTasks("grunt-contrib-jshint");
-	grunt.loadNpmTasks("grunt-jscs-checker");
+	grunt.loadNpmTasks("grunt-jscs");
 	grunt.loadNpmTasks("grunt-mocha-istanbul");
 
 	grunt.registerTask("test", [ "mocha_istanbul:coverage" ]);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-jscs-checker": "^0.4.4",
+    "grunt-jscs": "^0.6.1",
     "grunt-mocha-istanbul": "^1.4.1",
     "js-yaml": "^3.0.2",
     "sinon": "^1.10.2"


### PR DESCRIPTION
grunt-jscs-checker package was renamed to grunt-jscs 
- updated in package.json
- updated Gruntfile to load correct plugin
- updated generator template
- updated generator code
